### PR TITLE
Update version to 1.57

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "libgpg-error" %}
-{% set version = "1.51" %}
+{% set version = "1.57" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://gnupg.org/ftp/gcrypt/{{ name }}/{{ name }}-{{ version }}.tar.bz2
-  sha256: be0f1b2db6b93eed55369cdf79f19f72750c8c7c39fc20b577e724545427e6b2
+  sha256: ab807c81fbd2b8e1d6e3377383be802147c08818f87a82e87f85e5939c939def
 
 build:
   number: 0
@@ -19,6 +19,7 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - make
     - pkg-config

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "libgpg-error" %}
-{% set version = "1.57" %}
+{% set version = "1.58" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://gnupg.org/ftp/gcrypt/{{ name }}/{{ name }}-{{ version }}.tar.bz2
-  sha256: ab807c81fbd2b8e1d6e3377383be802147c08818f87a82e87f85e5939c939def
+  sha256: f943aea9a830a8bd938e5124b579efaece24a3225ff4c3d27611a80ce1260c27
 
 build:
   number: 0


### PR DESCRIPTION
libgpg-error 1.57

[PKG-11360](https://anaconda.atlassian.net/browse/PKG-11360)
https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgpg-error.git

Changes:
- new version number

[PKG-11360]: https://anaconda.atlassian.net/browse/PKG-11360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ